### PR TITLE
Update embedded-hal to 1.0

### DIFF
--- a/dw1000/Cargo.toml
+++ b/dw1000/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dw1000"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Hanno Braun <hanno@braun-embedded.com>"]
-edition = "2018"
+edition = "2021"
 description = "Driver for the Decawave DW1000 UWB wireless transceiver chip, providing radio communication based on IEEE 802.15.4 and distance measurement"
 documentation = "https://docs.rs/dw1000"
 repository = "https://github.com/braun-embedded/rust-dw1000"
@@ -16,13 +16,14 @@ keywords = [
     "embedded-hal",
     "embedded-hal-driver",
 ]
+rust-version = "1.79"
 
 [badges]
 travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 [dependencies]
 byte = "0.2.6"
-embedded-hal = "0.2.6"
+embedded-hal = "1.0.0"
 ieee802154 = "0.6.0"
 nb = "1.0.0"
 fixed = "1.11.0"

--- a/dw1000/src/hl/mod.rs
+++ b/dw1000/src/hl/mod.rs
@@ -12,14 +12,10 @@
 use crate::ll;
 use core::{fmt, num::Wrapping};
 
-pub use awake::*;
 pub use error::*;
 pub use ready::*;
 pub use receiving::*;
-pub use sending::*;
-pub use sleeping::*;
 pub use state_impls::*;
-pub use uninitialized::*;
 
 mod awake;
 mod error;
@@ -31,14 +27,14 @@ mod state_impls;
 mod uninitialized;
 
 /// Entry point to the DW1000 driver API
-pub struct DW1000<SPI, CS, State> {
-    ll: ll::DW1000<SPI, CS>,
+pub struct DW1000<SPI, State> {
+    ll: ll::DW1000<SPI>,
     seq: Wrapping<u8>,
     state: State,
 }
 
 // Can't be derived without putting requirements on `SPI` and `CS`.
-impl<SPI, CS, State> fmt::Debug for DW1000<SPI, CS, State>
+impl<SPI, State> fmt::Debug for DW1000<SPI, State>
 where
     State: fmt::Debug,
 {

--- a/dw1000/src/hl/sleeping.rs
+++ b/dw1000/src/hl/sleeping.rs
@@ -1,20 +1,15 @@
 use crate::{Error, Ready, Sleeping, DW1000};
-use embedded_hal::{blocking::spi, digital::v2::OutputPin};
+use embedded_hal::delay::DelayNs;
+use embedded_hal::spi::SpiDevice;
 
-impl<SPI, CS> DW1000<SPI, CS, Sleeping>
+impl<SPI> DW1000<SPI, Sleeping>
 where
-    SPI: spi::Transfer<u8> + spi::Write<u8>,
-    CS: OutputPin,
+    SPI: SpiDevice,
 {
     /// Wakes the radio up.
-    pub fn wake_up<DELAY: embedded_hal::blocking::delay::DelayUs<u16>>(
-        mut self,
-        delay: &mut DELAY,
-    ) -> Result<DW1000<SPI, CS, Ready>, Error<SPI, CS>> {
+    pub fn wake_up(mut self, delay: &mut impl DelayNs) -> Result<DW1000<SPI, Ready>, Error<SPI>> {
         // Wake up using the spi
-        self.ll.assert_cs_low().map_err(|e| Error::Spi(e))?;
-        delay.delay_us(850 * 2);
-        self.ll.assert_cs_high().map_err(|e| Error::Spi(e))?;
+        self.ll.wake_up(850 * 2)?;
 
         // Now we must wait 4 ms so all the clocks start running.
         delay.delay_us(4000 * 2);

--- a/dw1000/src/hl/uninitialized.rs
+++ b/dw1000/src/hl/uninitialized.rs
@@ -1,22 +1,18 @@
 use crate::{ll, Error, Ready, Uninitialized, DW1000};
 use core::num::Wrapping;
-use embedded_hal::{
-    blocking::{delay::DelayMs, spi},
-    digital::v2::OutputPin,
-};
+use embedded_hal::{delay::DelayNs, spi::SpiDevice};
 
-impl<SPI, CS> DW1000<SPI, CS, Uninitialized>
+impl<SPI> DW1000<SPI, Uninitialized>
 where
-    SPI: spi::Transfer<u8> + spi::Write<u8>,
-    CS: OutputPin,
+    SPI: SpiDevice,
 {
     /// Create a new instance of `DW1000`
     ///
     /// Requires the SPI peripheral and the chip select pin that are connected
     /// to the DW1000.
-    pub fn new(spi: SPI, chip_select: CS) -> Self {
+    pub fn new(spi: SPI) -> Self {
         DW1000 {
-            ll: ll::DW1000::new(spi, chip_select),
+            ll: ll::DW1000::new(spi),
             seq: Wrapping(0),
             state: Uninitialized,
         }
@@ -32,10 +28,7 @@ where
     /// Please note that this method assumes that you kept the default
     /// configuration. It is generally recommended not to change configuration
     /// before calling this method.
-    pub fn init<D: DelayMs<u8>>(
-        mut self,
-        delay: &mut D,
-    ) -> Result<DW1000<SPI, CS, Ready>, Error<SPI, CS>> {
+    pub fn init<D: DelayNs>(mut self, delay: &mut D) -> Result<DW1000<SPI, Ready>, Error<SPI>> {
         // Set AGC_TUNE1. See user manual, section 2.5.5.1.
         self.ll.agc_tune1().write(|w| w.value(0x8870))?;
 

--- a/dwm1001/Cargo.toml
+++ b/dwm1001/Cargo.toml
@@ -24,11 +24,14 @@ embedded-hal = "0.2.6"
 embedded-timeout-macros = "0.3.0"
 lis2dh12 = "0.6.6"
 cortex-m-rt = { version = "0.7.1", optional = true }
-dw1000 = { version = "0.6.0", path = "../dw1000" }
+dw1000 = { version = "0.6.0" }
 nrf52832-hal = { version = "0.14.0", default-features = false, features = [
     "xxAA-package",
 ] }
 
+[lib]
+test = false
+bench = false
 
 [dev-dependencies]
 heapless = "0.7.8"


### PR DESCRIPTION
This updates the `embedded-hal` version of `dw1000` to 1.0. I left out the `dwm1001` as updating all the examples would take a long time, and it is unclera to me how I would translate the `block_timeout!` calls into modern code, since `embedded-hal-nb` never really took off. I guess these would need to be translated to `async`, but unfortunately I neither have the time, nor a board to test those changes.

Are you willing to merge a partial upgrade?